### PR TITLE
sanitize-anime-name-for-windows-folder-path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5...3.30)
-project(AnimepaheCLI VERSION 0.2.0 LANGUAGES CXX)
+project(AnimepaheCLI VERSION 0.2.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/libs/animepahe.cpp
+++ b/libs/animepahe.cpp
@@ -453,8 +453,10 @@ namespace AnimepaheCLI
         }
         else
         {
+            /* sanitize anime name for windows support */
+            std::string dirName = sanitizeForWindowsPath(series_name);
             Downloader downloader(directLinks);
-            downloader.setDownloadDirectory(series_name);
+            downloader.setDownloadDirectory(dirName);
             downloader.startDownloads();
             fmt::print("\n\x1b[2K\r");
 
@@ -492,9 +494,9 @@ namespace AnimepaheCLI
                 std::cout << "\n * Zipping..\n";
 
                 /* Use the enhanced progress callback */
-                std::string zipName = replaceSpacesWithUnderscore(series_name);
+                std::string zipName = replaceSpacesWithUnderscore(dirName);
                 bool success = ZipUtils::zip_directory(
-                    fmt::format("./{}", series_name),
+                    fmt::format("./{}", dirName),
                     fmt::format("{}.zip", zipName),
                     removeSource,
                     enhanced_progress
@@ -513,8 +515,8 @@ namespace AnimepaheCLI
                     fmt::print(fmt::fg(fmt::color::cyan), fmt::format("{}.zip", zipName));
                     std::cout << ")" << std::endl;
                 }
-                std::cout << std::endl;
             }
+            std::cout << std::endl;
         }
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -41,7 +41,7 @@ int main(int argc, char *argv[])
     ("h,help", "Print usage");
 
     /* version tag */
-    const std::string VERSION = "v0.2.0-beta";
+    const std::string VERSION = "v0.2.1-beta";
 
     try
     {

--- a/resource.rc
+++ b/resource.rc
@@ -4,8 +4,8 @@
 IDI_ICON1 ICON "res/icon.ico"
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION     0,2,0,0
-PRODUCTVERSION  0,2,0,0
+FILEVERSION     0,2,1,0
+PRODUCTVERSION  0,2,1,0
 FILEFLAGSMASK   0x3fL
 FILEFLAGS       0x0L
 FILEOS          0x40004L
@@ -18,9 +18,9 @@ BEGIN
         BEGIN
             VALUE "CompanyName",      "Danushka-Madushan\0"
             VALUE "FileDescription",  "Animepahe CLI Downloader\0"
-            VALUE "FileVersion",      "0.2.0.0\0"
+            VALUE "FileVersion",      "0.2.1.0\0"
             VALUE "ProductName",      "Animepahe-CLI\0"
-            VALUE "ProductVersion",   "0.2.0.0\0"
+            VALUE "ProductVersion",   "0.2.1.0\0"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
- bump from v0.2.0 to v0.2.1
- sanitize anime name for windows folder path support