### PR TITLE
Linux compatibility - conditional inclusion of githubupdater

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,18 +67,22 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(absl re2 cxxopts fmt cpr pugixml json zip)
 
-add_executable(
-  animepahe-cli-beta
-
+set(SRC_FILES
   main.cpp
   libs/utils.cpp
   libs/animepahe.cpp
   libs/kwikpahe.cpp
-  libs/githubupdater.cpp
   libs/downloader.cpp
   libs/ziputils.cpp
   resource.rc
 )
+
+# Include Windows-only updater
+if(WIN32)
+  list(APPEND SRC_FILES libs/githubupdater.cpp)
+endif()
+
+add_executable(animepahe-cli-beta ${SRC_FILES})
 
 target_include_directories(animepahe-cli-beta
   PRIVATE

--- a/libs/githubupdater_stub.h
+++ b/libs/githubupdater_stub.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <string>
+#include <optional>
+
+struct Release {
+    std::string tag_name;
+};
+
+class GitHubUpdater {
+public:
+    GitHubUpdater(const std::string&, const std::string&, const std::string&, const std::string& = "") {}
+    std::optional<Release> checkForUpdate() { return std::nullopt; }
+    void checkAndUpdate(bool = false) {}
+};

--- a/main.cpp
+++ b/main.cpp
@@ -4,7 +4,11 @@
 #include <string>
 #include <utils.hpp>
 #include <animepahe.hpp>
+#ifdef _WIN32
 #include <githubupdater.hpp>
+#else
+#include "libs/githubupdater_stub.h"
+#endif
 
 using namespace AnimepaheCLI;
 


### PR DESCRIPTION
This PR adds githubupdater_stub.h which is conditionally included in main.cpp and cmakelists

githubupdater_stub is essentially just a minimal file and will disable the functionality of the updater (due to the requirement of windows import)

project can now be built on linux