### PR TITLE
Add single episode download support and document macOS ARM64 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ This is a **beta version** and may encounter issues during operation. The curren
 3. Open Command Prompt or PowerShell in that directory
 
 ### Building from Source
+
+#### Windows/Linux
 ```bash
 git clone https://github.com/Danushka-Madushan/animepahe-cli.git
 cd animepahe-cli
@@ -39,6 +41,37 @@ mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
 cmake --build . --config Release
 ```
+
+#### macOS (ARM64/Apple Silicon)
+macOS requires a patch to the Abseil dependency for ARM64 compatibility:
+
+```bash
+# Install dependencies
+brew install cmake
+
+# Clone and configure
+git clone https://github.com/Danushka-Madushan/animepahe-cli.git
+cd animepahe-cli
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-arch arm64"
+
+# Patch Abseil for ARM64 compatibility
+# Edit: build/_deps/absl-src/absl/copts/AbseilConfigureCopts.cmake
+# Find line ~15: if(APPLE AND CMAKE_CXX_COMPILER_ID MATCHES [[Clang]])
+# Add after that line:
+#   if(CMAKE_CXX_FLAGS MATCHES "arm64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+#     set(ABSL_RANDOM_RANDEN_COPTS "${ABSL_RANDOM_HWAES_ARM64_FLAGS}")
+#   else()
+# Then add matching endif() before the elseif on line ~60
+
+# Reconfigure and build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-arch arm64"
+cmake --build . --config Release
+
+# Binary will be at: build/animepahe-cli-beta
+```
+
+**Note**: This is a community-contributed workaround. Official macOS support is not planned by the maintainer.
 
 ## 📖 Usage
 
@@ -60,7 +93,7 @@ animepahe-cli-beta.exe [OPTIONS]
 ### Optional Arguments
 | Flag | Long Form | Description | Example |
 |------|-----------|-------------|---------|
-| `-e` | `--episodes` | Episode selection (`all` or range like `1-12`). Defaults to `all` if not provided | `all`, `1-12`, `5-25` |
+| `-e` | `--episodes` | Episode selection (`all`, single episode like `3`, or range like `1-12`). Defaults to `all` if not provided | `all`, `3`, `1-12`, `5-25` |
 | `-q` | `--quality` | Target video quality (`-1` for lowest, `0` for max, or custom like `720`, `1080`) | `-1`, `0`, `720`, `1080`, `360` |
 | `-x` | `--export` | Export download links to file (cancels download) | |
 | `-f` | `--filename` | Custom filename for exported file (use with `-x`) | `"akame-ga-kill-links.txt"` |
@@ -87,6 +120,11 @@ animepahe-cli-beta.exe -l "https://animepahe.si/anime/dcb2b21f-a70d-84f7-fbab-58
 #### Download Specific Episode Range
 ```bash
 animepahe-cli-beta.exe -l "https://animepahe.si/anime/dcb2b21f-a70d-84f7-fbab-580701484066" -e 1-12
+```
+
+#### Download Single Episode
+```bash
+animepahe-cli-beta.exe -l "https://animepahe.si/anime/dcb2b21f-a70d-84f7-fbab-580701484066" -e 3
 ```
 
 #### Download with Specific Quality
@@ -148,6 +186,7 @@ animepahe-cli-beta.exe -l "https://animepahe.si/anime/dcb2b21f-a70d-84f7-fbab-58
 ### Episode Selection
 - **Default behavior**: When `-e` or `--episodes` is not provided, all episodes are downloaded
 - **`all`**: Explicitly downloads all available episodes
+- **Single episode**: Use a single number like `3` to download one episode
 - **Range format**: Use formats like `1-12` or `5-25` for specific episode ranges
 - Episode selection applies to both download and export operations
 
@@ -180,7 +219,7 @@ animepahe-cli-beta.exe -l "https://animepahe.si/anime/dcb2b21f-a70d-84f7-fbab-58
 ### Platform Support
 - **Windows**: Fully supported with native executable
 - **Linux**: Potential future support under consideration
-- **macOS**: Not supported and no plans for support
+- **macOS**: Buildable from source on ARM64 (Apple Silicon) with patches (see macOS build instructions below)
 
 ### Dependencies
 - **CPR**: HTTP client library for C++

--- a/libs/utils.cpp
+++ b/libs/utils.cpp
@@ -148,16 +148,29 @@ namespace AnimepaheCLI
             return true;
 
         int start, end;
-        return RE2::FullMatch(input, R"((\d+)-(\d+))", &start, &end) && start > 0 && end > start;
+        // Support single episode numbers like "3" or ranges like "1-12" or "3-3"
+        if (RE2::FullMatch(input, R"((\d+))", &start))
+            return start > 0;
+
+        return RE2::FullMatch(input, R"((\d+)-(\d+))", &start, &end) && start > 0 && end >= start;
     }
 
-    /* parse episodes 1-15 */
+    /* parse episodes 1-15 or single episode like 3 */
     std::vector<int> parseEpisodeRange(const std::string &input)
     {
         int start, end;
+
+        // Check for single episode number like "3"
+        if (RE2::FullMatch(input, R"((\d+))", &start))
+        {
+            if (start > 0)
+                return {start, start}; // Treat as range 3-3
+        }
+
+        // Check for range like "1-12" or "3-3"
         if (RE2::FullMatch(input, R"((\d+)-(\d+))", &start, &end))
         {
-            if (start > 0 && end > start)
+            if (start > 0 && end >= start)
             {
                 return {start, end};
             }

--- a/main.cpp
+++ b/main.cpp
@@ -35,10 +35,10 @@ int main(int argc, char *argv[])
     cxxopts::Options options("animepahe-cli", "AnimePahe CLI Downloader");
     options.add_options()
     ("l,link", "Input anime series link or a single episode link", cxxopts::value<std::string>())
-    ("e,episodes", "Specify episodes to download (all, 1-15)", cxxopts::value<std::string>()->default_value("all"))
+    ("e,episodes", "Specify episodes to download (all, 3, 1-15)", cxxopts::value<std::string>()->default_value("all"))
     ("q,quality", "Set target quality", cxxopts::value<int>()->default_value("0"))
     ("x,export", "Export download links to a text file", cxxopts::value<bool>()->default_value("false"))
-    ("f,filename", "Custom filname for exported file", cxxopts::value<std::string>()->default_value("links.txt"))
+    ("f,filename", "Custom filename for exported file", cxxopts::value<std::string>()->default_value("links.txt"))
     ("z,zip", "Create a zip from downloaded items", cxxopts::value<bool>()->default_value("false"))
     ("rm-source", "Delete source files after zipping", cxxopts::value<bool>()->default_value("false"))
     ("upgrade", "Update to the latest version")
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
         }
         if (!isValidEpisodeRangeFormat(episodes))
         {
-            throw std::runtime_error("Invalid episode range format. Use 'all' or '1-15'.");
+            throw std::runtime_error("Invalid episode range format. Use 'all', '3', or '1-15'.");
         }
         if (!isValidTxtFilename(export_filename))
         {


### PR DESCRIPTION
## Summary
This PR adds support for single episode downloads and provides comprehensive documentation for building on macOS ARM64 (Apple Silicon).

## Problem
Currently, users cannot download single episodes using intuitive syntax like `-e 3`. They must use workarounds like `-e 3-4` or provide direct episode URLs. Additionally, the README states "macOS: Not supported and no plans for support" despite the project being buildable on ARM64 Macs with minor patches.

## Solution
### 1. Single Episode Download Support
- Modified `isValidEpisodeRangeFormat()` to accept single episode numbers
- Updated `parseEpisodeRange()` to treat single numbers as ranges (e.g., `3` → `3-3`)
- Updated help text, error messages, and documentation

### 2. macOS ARM64 Build Documentation
- Added detailed build instructions for macOS with required Abseil ARM64 patch
- Updated Platform Support section to reflect actual buildability
- Added usage examples for single episode downloads

### 3. Minor Fixes
- Fixed typo: "filname" → "filename" in help text

## Changes
- `libs/utils.cpp`: Episode validation and parsing logic
- `main.cpp`: Help text and error messages
- `README.md`: Documentation updates

## Testing
✅ Single episode: `-e 3` → `[EP03, EP03]`  
✅ Same-number range: `-e 5-5` → `[EP05, EP05]`  
✅ Normal range: `-e 1-3` → `[EP01, EP03]` (no regression)  
✅ Help text displays correctly  

## Screenshots
**Before:**
```
Error: Invalid episode range format. Use 'all' or '1-15'.
```

**After:**
```bash
# Now works!
animepahe-cli-beta -e 3
* episodesRange: [EP03, EP03]
```

## Related Issues
This addresses user confusion and improves UX for single episode downloads.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)