### PR TITLE
Fix CMakeLists.txt to conditionally include Windows-only files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,11 +74,11 @@ set(SRC_FILES
   libs/kwikpahe.cpp
   libs/downloader.cpp
   libs/ziputils.cpp
-  resource.rc
 )
 
-# Include Windows-only updater
+# Include Windows-only files
 if(WIN32)
+  list(APPEND SRC_FILES resource.rc)
   list(APPEND SRC_FILES libs/githubupdater.cpp)
 endif()
 


### PR DESCRIPTION
## Summary
This PR fixes a cross-platform build issue where Windows-only files were unconditionally included in the build, causing potential failures on Linux/macOS.

## Problem
The `resource.rc` file was included in `SRC_FILES` unconditionally on line 77, but this is a Windows resource file that doesn't exist on Linux/macOS systems. This would cause build failures on non-Windows platforms.

## Solution
Moved `resource.rc` into the existing `WIN32` conditional block, matching the pattern already used for `libs/githubupdater.cpp`.

## Changes
- Moved `resource.rc` from unconditional `SRC_FILES` to the `if(WIN32)` block
- Updated comment from "Include Windows-only updater" to "Include Windows-only files" for clarity
- Consolidated all Windows-specific files under a single conditional

## Impact
✅ Fixes potential build failures on Linux/macOS  
✅ No functional changes for Windows builds  
✅ Improves cross-platform compatibility

## Testing
✅ macOS ARM64 build succeeds with this change  
✅ Binary created successfully (1.7MB)  
✅ Binary executes and help text displays correctly  

## Related Work
This complements the GitHub Actions workflow which already comments out `CPR_USE_SYSTEM_CURL` for CI/CD builds. Both changes improve cross-platform compatibility.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)