### PR TITLE
fix: update AnimePahe domain from .si to .com and improve compatibility

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -22,11 +22,6 @@ jobs:
     - name: Setup MSVC
       uses: microsoft/setup-msbuild@v2
     
-    - name: Modify CMakeLists.txt for CI
-      run: |
-        # Comment out the CPR_USE_SYSTEM_CURL line
-        (Get-Content CMakeLists.txt) -replace 'set\(CPR_USE_SYSTEM_CURL ON\)', '# set(CPR_USE_SYSTEM_CURL ON) # Disabled for CI' | Set-Content CMakeLists.txt
-    
     - name: Configure CMake
       run: |
         cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -A x64
@@ -95,11 +90,6 @@ jobs:
     
     - name: Setup MSVC
       uses: microsoft/setup-msbuild@v2
-    
-    - name: Modify CMakeLists.txt for CI
-      run: |
-        # Comment out the CPR_USE_SYSTEM_CURL line
-        (Get-Content CMakeLists.txt) -replace 'set\(CPR_USE_SYSTEM_CURL ON\)', '# set(CPR_USE_SYSTEM_CURL ON) # Disabled for CI' | Set-Content CMakeLists.txt
     
     - name: Configure CMake
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(AnimepaheCLI VERSION 0.2.9 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CPR_USE_SYSTEM_CURL ON)
+set(CPR_USE_SYSTEM_CURL OFF)
 
 # Configure Abseil options before making it available
 set(ABSL_PROPAGATE_CXX_STD ON)

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ This tool is for educational purposes only. Users are responsible for complying 
 
 ## 🔗 Links
 
-- [AnimePahe](https://animepahe.org) - Source website (primary). Legacy: https://animepahe.ru
+- [AnimePahe](https://animepahe.com) - Source website (primary). Legacy: https://animepahe.org / https://animepahe.ru
 - [Stream Proxy Worker](https://github.com/Danushka-Madushan/stream-proxy-worker) - Cloudflare Worker that proxies streaming links
 - [Issues](https://github.com/Danushka-Madushan/animepahe-cli/issues) - Bug reports and feature requests
 - [Releases](https://github.com/Danushka-Madushan/animepahe-cli/releases) - Download latest versions

--- a/libs/utils.cpp
+++ b/libs/utils.cpp
@@ -132,14 +132,14 @@ namespace AnimepaheCLI
 
     bool isFullSeriesURL(const std::string &url)
     {
-        // Accept both legacy .ru and new primary .si domains
-        return RE2::FullMatch(url, R"(^https:\/\/animepahe\.(ru|si)\/anime\/[a-f0-9\-]{36}$)");
+        // Accept .com (current), .org (primary), and legacy .ru/.si domains
+        return RE2::FullMatch(url, R"(^https:\/\/animepahe\.(com|org|ru|si)\/anime\/[a-f0-9\-]{36}$)");
     }
 
     bool isEpisodeURL(const std::string &url)
     {
-        // Accept both legacy .ru and new primary .si domains
-        return RE2::FullMatch(url, R"(^https:\/\/animepahe\.(ru|si)\/play\/[a-f0-9\-]{36}\/[a-f0-9]{64}$)");
+        // Accept .com (current), .org (primary), and legacy .ru/.si domains
+        return RE2::FullMatch(url, R"(^https:\/\/animepahe\.(com|org|ru|si)\/play\/[a-f0-9\-]{36}\/[a-f0-9]{64}$)");
     }
 
     bool isValidEpisodeRangeFormat(const std::string &input)


### PR DESCRIPTION
- Updated URL validators to accept .com and .org alongside legacy .ru/.si

- README links section updated to reflect .com as primary domain

- No changes to business logic or API endpoints